### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can also configure default credentials and the region via the `Aws.config`
 hash. The `Aws.config` hash takes precedence over environment variables.
 
 ```ruby
-require 'aws-sdk'
+require 'aws-sdk-core'
 
 Aws.config.update(
   region: 'us-west-2',


### PR DESCRIPTION
# Patching readme.md 

This change reflects the new gem being required  `aws-sdk` -> `aws-sdk-core` on the example to use config hashes when setting up the gem.